### PR TITLE
Add a feature to create color variables if they don't exist yet

### DIFF
--- a/resources/app.js
+++ b/resources/app.js
@@ -3,7 +3,8 @@ document.addEventListener("contextmenu", e => e.preventDefault())
 let allInputs = [];
 [
   'option-1',
-  'option-2'
+  'option-2',
+  'option-3'
 ].forEach(id => {
   allInputs.push(document.getElementById(id))
 })

--- a/resources/dialog.html
+++ b/resources/dialog.html
@@ -24,7 +24,7 @@
       </div>
       <div class='option'>
         <label for='option-3'>
-          <span><input id='option-3' type='checkbox' checked /> Create Color Variables if they don't exist yet</span>
+          <span><input id='option-3' type='checkbox' /> Create Color Variables if they don't exist yet</span>
           <small>Create Color Variables for all colors in the document that don't match with an existing Color Variable.</small>
         </label>
       </div>

--- a/resources/dialog.html
+++ b/resources/dialog.html
@@ -22,6 +22,12 @@
           <small>Update all Layer and Text Styles to use the document's existing Color Variables.</small>
         </label>
       </div>
+      <div class='option'>
+        <label for='option-3'>
+          <span><input id='option-3' type='checkbox' checked /> Create Color Variables if they don't exist yet</span>
+          <small>Create Color Variables for all colors in the document that don't match with an existing Color Variable.</small>
+        </label>
+      </div>
       <footer><button id='cancel' class='secondary'>Cancel</button> <button id='submit'>Migrate</button></footer>
     </div>
     <script src='../resources_app.js'></script>

--- a/src/my-command.js
+++ b/src/my-command.js
@@ -11,7 +11,7 @@ export function migrate(context) {
   const options = {
     identifier: webviewIdentifier,
     width: 400,
-    height: 236,
+    height: 300,
     show: false,
     resizable: false,
     title: 'Color Variables Migrator',

--- a/src/my-command.js
+++ b/src/my-command.js
@@ -148,9 +148,6 @@ function doUseColorSwatchesInStyles(context) {
   })
 }
 
-function clog(message){
-  console.log(message);
-}
 
 function createMissingSwatches(context) {
   const currentSwatches = new Map()
@@ -168,7 +165,6 @@ function createMissingSwatches(context) {
       .filter(item => item.fillType == 'Color')
       .forEach(item => {
         if (!currentSwatches.has(item.color)) {
-          clog("Fill/border in layer " + layer.name + " doesn't map to any color variable");
           var elementToUpdate = {
             "layer": layer,
             "item": item,
@@ -187,7 +183,6 @@ function createMissingSwatches(context) {
       })
     if (layer.style.textColor) {
       if (!currentSwatches.has(layer.style.textColor)) {
-        clog("Text color in layer " + layer.name + " doesn't map to any color variable");
         var elementToUpdate = {
           "layer": layer,
           "type": ItemType.text
@@ -212,7 +207,6 @@ function createMissingSwatches(context) {
     style.style.fills.concat(style.style.borders).forEach(item => {
       if (item.fillType == 'Color') {
         if (!currentSwatches.has(item.color)) {
-          clog("Fill/border in style " + style.name + " doesn't map to any color variable");
           var elementToUpdate = {
             "style": style,
             "item": item,
@@ -235,7 +229,6 @@ function createMissingSwatches(context) {
   const allTextStyles = doc.sharedTextStyles
   allTextStyles.forEach(style => {
     if (!currentSwatches.has(style.style.textColor)) {
-      clog("Color in text style " + style.name + " doesn't map to any color variable");
       var elementToUpdate = {
         "style": style,
         "type": ItemType.textStyle
@@ -253,10 +246,8 @@ function createMissingSwatches(context) {
   })
 
 
-  clog("Adding non-existing swatches");
   missingSwatches.forEach(function (value, key) {
 
-    clog("-- Adding swatch: " + key.toString() + ", used in " + value.length + " places");
     doc.swatches.push(sketch.Swatch.from({
       name: automatedPrefix + key,
       color: key.toString()
@@ -265,22 +256,18 @@ function createMissingSwatches(context) {
     value.forEach(function (elementToUpdate) {
       switch (elementToUpdate.type) {
         case ItemType.shape:
-          clog("---- Will update layer: " + elementToUpdate.layer.name)
           elementToUpdate.item.color = doc.swatches[doc.swatches.length - 1].referencingColor;
           if (!updatedLayersMap.has(elementToUpdate.layer)) updatedLayersMap.set(elementToUpdate.layer, true);
           break;
         case ItemType.text:
-          clog("---- Will update text layer: " + elementToUpdate.layer.name)
           elementToUpdate.layer.style.textColor = doc.swatches[doc.swatches.length - 1].referencingColor;
           if (!updatedLayersMap.has(elementToUpdate.layer)) updatedLayersMap.set(elementToUpdate.layer, true);
           break;
         case ItemType.layerStyle:
-          clog("---- Will update layer style: " + elementToUpdate.style.name)
           elementToUpdate.item.color = doc.swatches[doc.swatches.length - 1].referencingColor;
           if (!updatedStylesMap.has(elementToUpdate.style)) updatedStylesMap.set(elementToUpdate.style, true);
           break;
         case ItemType.textStyle:
-          clog("---- Will update text style: " + elementToUpdate.style.name)
           elementToUpdate.style.style.textColor = doc.swatches[doc.swatches.length - 1].referencingColor;
           if (!updatedStylesMap.has(elementToUpdate.style)) updatedStylesMap.set(elementToUpdate.style, true);
           break;

--- a/src/my-command.js
+++ b/src/my-command.js
@@ -53,6 +53,7 @@ export function onShutdown() {
 function performMigration(options) {
   const useColorSwatchesInLayers = options['option-1']
   const useColorSwatchesInStyles = options['option-2']
+  const createColorSwatches = options['option-3']
 
   if (!useColorSwatchesInLayers && !useColorSwatchesInStyles) {
     // Yo, you know there's a Cancel button for this, right?
@@ -64,6 +65,10 @@ function performMigration(options) {
   if (useColorSwatchesInStyles) {
     doUseColorSwatchesInStyles()
   }
+  if (createColorSwatches) {
+    console.log("We're gonna create swatcheeees")
+  }
+
   UI.message('Color migration complete.')
 }
 

--- a/src/my-command.js
+++ b/src/my-command.js
@@ -7,6 +7,14 @@ const Swatch = sketch.Swatch
 const doc = sketch.getSelectedDocument()
 const webviewIdentifier = 'color-variables-migrator.webview'
 
+const automatedPrefix = "Auto-generated/";
+const ItemType = {
+  shape: 'shape',
+  text: 'text',
+  layerStyle: 'layerstyle',
+  textStyle: 'textstyle'
+}
+
 export function migrate(context) {
   const options = {
     identifier: webviewIdentifier,
@@ -66,7 +74,7 @@ function performMigration(options) {
     doUseColorSwatchesInStyles()
   }
   if (createColorSwatches) {
-    console.log("We're gonna create swatcheeees")
+    createMissingSwatches()
   }
 
   UI.message('Color migration complete.')
@@ -138,6 +146,147 @@ function doUseColorSwatchesInStyles(context) {
   stylesCanBeUpdated.forEach(pair => {
     pair.instance.syncWithSharedStyle(pair.style)
   })
+}
+
+function clog(message){
+  console.log(message);
+}
+
+function createMissingSwatches(context) {
+  const currentSwatches = new Map()
+  const missingSwatches = new Map()
+
+  doc.swatches.forEach(function (swatch) {
+    currentSwatches.set(swatch.color, swatch);
+  });
+
+  const allLayers = sketch.find('*') // TODO: optimise this query: ShapePath, SymbolMaster, Text, SymbolInstance
+  const updatedLayersMap = new Map();
+  allLayers.forEach(layer => {
+    layer.style.fills
+      .concat(layer.style.borders)
+      .filter(item => item.fillType == 'Color')
+      .forEach(item => {
+        if (!currentSwatches.has(item.color)) {
+          clog("Fill/border in layer " + layer.name + " doesn't map to any color variable");
+          var elementToUpdate = {
+            "layer": layer,
+            "item": item,
+            "type": ItemType.shape
+          }
+          if (!missingSwatches.has(item.color)) {
+            var elementsToUpdate = []
+            elementsToUpdate.push(elementToUpdate)
+            missingSwatches.set(item.color, elementsToUpdate);
+          }
+          else {
+            var elementsToUpdate = missingSwatches.get(item.color);
+            elementsToUpdate.push(elementToUpdate)
+          }
+        }
+      })
+    if (layer.style.textColor) {
+      if (!currentSwatches.has(layer.style.textColor)) {
+        clog("Text color in layer " + layer.name + " doesn't map to any color variable");
+        var elementToUpdate = {
+          "layer": layer,
+          "type": ItemType.text
+        }
+        if (!missingSwatches.has(layer.style.textColor)) {
+          var elementsToUpdate = [];
+          elementsToUpdate.push(elementToUpdate)
+          missingSwatches.set(layer.style.textColor, elementsToUpdate);
+        }
+        else {
+          var elementsToUpdate = missingSwatches.get(layer.style.textColor);
+          elementsToUpdate.push(elementToUpdate)
+        }
+      }
+    }
+  })
+
+
+  const allLayerStyles = doc.sharedLayerStyles;
+  const updatedStylesMap = new Map()
+  allLayerStyles.forEach(style => {
+    style.style.fills.concat(style.style.borders).forEach(item => {
+      if (item.fillType == 'Color') {
+        if (!currentSwatches.has(item.color)) {
+          clog("Fill/border in style " + style.name + " doesn't map to any color variable");
+          var elementToUpdate = {
+            "style": style,
+            "item": item,
+            "type": ItemType.layerStyle
+          }
+          if (!missingSwatches.has(item.color)) {
+            var elementsToUpdate = []
+            elementsToUpdate.push(elementToUpdate)
+            missingSwatches.set(item.color, elementsToUpdate)
+          }
+          else {
+            var elementsToUpdate = missingSwatches.get(item.color)
+            elementsToUpdate.push(elementToUpdate)
+          }
+        }
+      }
+    })
+  })
+
+  const allTextStyles = doc.sharedTextStyles
+  allTextStyles.forEach(style => {
+    if (!currentSwatches.has(style.style.textColor)) {
+      clog("Color in text style " + style.name + " doesn't map to any color variable");
+      var elementToUpdate = {
+        "style": style,
+        "type": ItemType.textStyle
+      }
+      if (!missingSwatches.has(style.style.textColor)) {
+        var elementsToUpdate = []
+        elementsToUpdate.push(elementToUpdate)
+        missingSwatches.set(style.style.textColor, elementsToUpdate)
+      }
+      else {
+        var elementsToUpdate = missingSwatches.get(style.style.textColor)
+        elementsToUpdate.push(elementToUpdate)
+      }
+    }
+  })
+
+
+  clog("Adding non-existing swatches");
+  missingSwatches.forEach(function (value, key) {
+
+    clog("-- Adding swatch: " + key.toString() + ", used in " + value.length + " places");
+    doc.swatches.push(sketch.Swatch.from({
+      name: automatedPrefix + key,
+      color: key.toString()
+    }));
+
+    value.forEach(function (elementToUpdate) {
+      switch (elementToUpdate.type) {
+        case ItemType.shape:
+          clog("---- Will update layer: " + elementToUpdate.layer.name)
+          elementToUpdate.item.color = doc.swatches[doc.swatches.length - 1].referencingColor;
+          if (!updatedLayersMap.has(elementToUpdate.layer)) updatedLayersMap.set(elementToUpdate.layer, true);
+          break;
+        case ItemType.text:
+          clog("---- Will update text layer: " + elementToUpdate.layer.name)
+          elementToUpdate.layer.style.textColor = doc.swatches[doc.swatches.length - 1].referencingColor;
+          if (!updatedLayersMap.has(elementToUpdate.layer)) updatedLayersMap.set(elementToUpdate.layer, true);
+          break;
+        case ItemType.layerStyle:
+          clog("---- Will update layer style: " + elementToUpdate.style.name)
+          elementToUpdate.item.color = doc.swatches[doc.swatches.length - 1].referencingColor;
+          if (!updatedStylesMap.has(elementToUpdate.style)) updatedStylesMap.set(elementToUpdate.style, true);
+          break;
+        case ItemType.textStyle:
+          clog("---- Will update text style: " + elementToUpdate.style.name)
+          elementToUpdate.style.style.textColor = doc.swatches[doc.swatches.length - 1].referencingColor;
+          if (!updatedStylesMap.has(elementToUpdate.style)) updatedStylesMap.set(elementToUpdate.style, true);
+          break;
+      }
+    });
+  });
 }
 
 function matchingSwatchForColor(color, name) {


### PR DESCRIPTION
Adds a feature to create color variables for all colors in the document that don't match with an existing Color Variable.

- New variables are create with a prefix (currently hard-coded as a const in my-command.js)

Improvements:
- createMissingSwatches() scans the whole document again. If doUseColorSwatchesInLayers() and/or doUseColorSwatchesInStyles() happen before, those iterations could be used to already map the missing swatches.
-  Could be useful to show, in the final UI.message, how many layers and styles have been updated, as well as how many swatches were added.